### PR TITLE
`ExceptT` for safer and composable operations

### DIFF
--- a/src/Cat/CatSpec.purs
+++ b/src/Cat/CatSpec.purs
@@ -34,7 +34,6 @@ instance monadFSTestCatM :: MonadFS Error TestCatM where
   readDir _ = pure Nil
   getMetadata _ = pure mockMetadata
 
--- spec :: ∀ m e. Monad m => Show e => MonadFS Error m => SpecT m Unit m Unit
 spec :: Spec Unit
 spec = describe "cat" do
   it "throws when reading an invalid path" do

--- a/src/Cat/CatSpec.purs
+++ b/src/Cat/CatSpec.purs
@@ -2,7 +2,9 @@ module PureShell.Cat.CatSpec (spec) where
 
 import Prelude
 
-import Control.Monad.Error.Class (class MonadError, class MonadThrow, throwError)
+import Control.Monad.Error.Class (throwError)
+import Control.Monad.Except (ExceptT(..))
+import Data.Either (Either(..))
 import Data.List (List(..))
 import Effect.Aff (Aff, Error, error)
 import PureShell.Cat.Cat (CatErrors(..), cat)
@@ -10,21 +12,17 @@ import PureShell.Common.MonadFS (class MonadFS)
 import PureShell.Mock.MonadFS (mockMetadata)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
-import Test.Spec.Assertions.String (shouldContain)
 
 newtype TestCatM a = TestCatM (Aff a)
 
-runTestCatM :: TestCatM ~> Aff
-runTestCatM (TestCatM a) = a
+runTest :: ∀ e r. ExceptT e TestCatM r -> Aff (Either e r)
+runTest (ExceptT (TestCatM a)) = a
 
 derive newtype instance functorTestCatM :: Functor TestCatM
 derive newtype instance applyTestCatM :: Apply TestCatM
 derive newtype instance applicativeTestCatM :: Applicative TestCatM
 derive newtype instance bindTestCatM :: Bind TestCatM
 derive newtype instance monadTestCatM :: Monad TestCatM
--- | Error handling
-derive newtype instance monadThrowTestCatM :: MonadThrow Error TestCatM
-derive newtype instance monadErrorTestCatM :: MonadError Error TestCatM
 
 instance monadFSTestCatM :: MonadFS Error TestCatM where
   exists fp
@@ -41,14 +39,14 @@ spec :: Spec Unit
 spec = describe "cat" do
   it "throws when reading an invalid path" do
     let invalidPath = "invalid/path"
-    errMsg <- runTestCatM $ cat invalidPath
-    errMsg `shouldEqual` show (FileNotExists invalidPath :: CatErrors Error)
+    err <- runTest $ cat invalidPath
+    err `shouldEqual` (Left $ FileNotExists invalidPath)
 
   it "throws when a directory is passed" do
     let dirPath = "someDir"
-    errMsg <- runTestCatM $ cat dirPath
-    errMsg `shouldContain` "Can\'t read file" -- show (FileNotReadable dirPath "Error: a dir")
+    err <- runTest $ cat dirPath
+    err `shouldEqual` (Left $ MiscError dirPath)
 
   it "succesfully reads the file" do
-    res <- runTestCatM $ cat "validFile"
-    res `shouldEqual` "file content"
+    res <- runTest $ cat "validFile"
+    res `shouldEqual` (Right $ "file content")

--- a/src/Common/MonadFS.purs
+++ b/src/Common/MonadFS.purs
@@ -7,19 +7,20 @@ module PureShell.Common.MonadFS
   , module ME
   ) where
 
+import Prelude
 
-import Control.Monad.Error.Class (class MonadError)
 import Control.Monad.Error.Class (try) as ME
+import Control.Monad.Except (ExceptT)
 import Data.List (List)
 import Node.FS.Stats (Stats) as NodeFs
 import Node.Path (FilePath)
 
 -- | Define a monad for file system operations
-class MonadError e m <= MonadFS e m | m -> e where
+class Monad m <= MonadFS e m | m -> e where
   -- checking
-  exists :: FilePath -> m Boolean
+  exists :: FilePath -> ExceptT e m Boolean
 
   -- reading files or dirs
-  readFile :: FilePath -> m String
-  readDir :: FilePath -> m (List FilePath)
-  getMetadata :: FilePath -> m NodeFs.Stats
+  readFile :: FilePath -> ExceptT e m String
+  readDir :: FilePath -> ExceptT e m (List FilePath)
+  getMetadata :: FilePath -> ExceptT e m NodeFs.Stats

--- a/src/Ls/Ls.purs
+++ b/src/Ls/Ls.purs
@@ -27,7 +27,7 @@ ls :: ∀ m e. MonadFS e m => FilePath -> LsOptions -> ExceptT LsError m String
 ls filePath options = do
   fileStats@(f /\ _) <- getFileStats filePath
   stats <- if isFile f
-    then fileStats # singleton # pure -- lift to a List
+    then pure $ singleton fileStats -- lift to a List
     else getDirStats filePath options
   pure $ summarizeStats stats
   where
@@ -51,7 +51,7 @@ getDirStats filePath options = do
   fileStats <- traverse (prefixWith filePath >>> getFileStats) dirContent
   pure $ respectOptions fileStats
   where
-    respectOptions = filter (\(fp /\ s) -> options.withHiddenFiles || not (isHidden fp))
+    respectOptions = filter (\(fp /\ _) -> options.withHiddenFiles || not (isHidden fp))
 
 -- | Helper function to format metadata
 -- |

--- a/src/Ls/Ls.purs
+++ b/src/Ls/Ls.purs
@@ -1,17 +1,18 @@
-module PureShell.Ls.Ls ( ls ) where
+module PureShell.Ls.Ls
+  ( LsError
+  , ls
+  ) where
 
 import Prelude
 
+import Control.Monad.Except (ExceptT, withExceptT)
 import Data.Array (intercalate)
-import Data.Bifunctor (bimap)
-import Data.Either (Either(..), fromRight)
 import Data.List (List, filter, singleton)
 import Data.Traversable (traverse)
 import Data.Tuple.Nested (type (/\), (/\))
 import Node.FS.Stats (Stats(..))
 import Node.Path (FilePath)
-import Partial.Unsafe (unsafePartial)
-import PureShell.Common.MonadFS (class MonadFS, getMetadata, readDir, try)
+import PureShell.Common.MonadFS (class MonadFS, getMetadata, readDir)
 import PureShell.Ls.Types (FileSystemType, LsOptions, isDirectory, isFile, isHidden, prefixWith, toFileSystemType)
 
 data LsError = FileOrDirNotExists
@@ -20,47 +21,37 @@ instance showLsError :: Show LsError where
   show _ = "No such file or directory"
 
 type FileStats = (FileSystemType /\ Stats)
-type ErrorOrFileStats = (Either LsError FileStats)
 
 -- | The main program of `ls` command
-ls :: ∀ m e. MonadFS e m => FilePath -> LsOptions -> m String
-ls filePath options = safeGetMetadata filePath >>= case _ of
-  Left e -> pure $ show e
-  Right fileStats@(f /\ _) -> do
-    stats <- if isFile f
-      then fileStats # singleton # pure -- lift to a List
-      else getDirStats filePath options
-    pure $ summarizeStats stats
-    where
-      summarizeStats :: List FileStats -> String
-      summarizeStats = map (flip formatStats options) >>> intercalate "\n"
+ls :: ∀ m e. MonadFS e m => FilePath -> LsOptions -> ExceptT LsError m String
+ls filePath options = do
+  fileStats@(f /\ _) <- getFileStats filePath
+  stats <- if isFile f
+    then fileStats # singleton # pure -- lift to a List
+    else getDirStats filePath options
+  pure $ summarizeStats stats
+  where
+    summarizeStats :: List FileStats -> String
+    summarizeStats = map (flip formatStats options) >>> intercalate "\n"
 
--- | Safely get metadata (stats) and transforms to `FileStats` if succeeds
-safeGetMetadata :: ∀ m e. MonadFS e m => FilePath -> m ErrorOrFileStats
-safeGetMetadata filePath = do
-  stats <- try $ getMetadata filePath
-  pure $ bimap
-    (const FileOrDirNotExists)
-    (\s -> (toFileSystemType filePath s) /\ s)
-    stats
+-- | Read raw metadata then transform it to `FileStats` type
+getFileStats :: ∀ m e. MonadFS e m => FilePath -> ExceptT LsError m FileStats
+getFileStats filePath = do
+  stats <- withExceptT (const FileOrDirNotExists) (getMetadata filePath)
+  pure $ (toFileSystemType filePath stats) /\ stats
 
 -- | When the given input is a directory, list that directory with the stats
--- | then join the result with a breakline
-getDirStats :: ∀ m e. MonadFS e m => FilePath -> LsOptions -> m (List FileStats)
-getDirStats filePath options = listDirsInside filePath >>= concludeStats >>> pure
+getDirStats :: ∀ m e
+  .  MonadFS e m
+  => FilePath
+  -> LsOptions
+  -> ExceptT LsError m (List FileStats)
+getDirStats filePath options = do
+  dirContent <- withExceptT (const FileOrDirNotExists) (readDir filePath)
+  fileStats <- traverse (prefixWith filePath >>> getFileStats) dirContent
+  pure $ respectOptions fileStats
   where
-    concludeStats :: List ErrorOrFileStats -> List FileStats
-    concludeStats = filter (case _ of
-        Left _ -> false
-        Right (fp /\ s) -> options.withHiddenFiles || not (isHidden fp)
-      )
-      >>> (\s -> unsafePartial $ eliminateLeft s)
-    eliminateLeft :: Partial => List ErrorOrFileStats -> List FileStats
-    eliminateLeft = map (fromRight)
-
--- | Read all files and directories in a given filepath
-listDirsInside :: ∀ m e. MonadFS e m => FilePath -> m (List ErrorOrFileStats)
-listDirsInside dir = readDir dir >>= traverse (prefixWith dir >>> safeGetMetadata)
+    respectOptions = filter (\(fp /\ s) -> options.withHiddenFiles || not (isHidden fp))
 
 -- | Helper function to format metadata
 -- |


### PR DESCRIPTION
Introduce `ExceptT` to make error handling composable and less boilerplate-y